### PR TITLE
Fix native module path.resolve with dlopen=true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function nativePlugin(options) {
         if (dlopen)
             return `
             function get() {
-              let p = require('path').resolve(${JSON.stringify(path)});
+              let p = require('path').resolve(__dirname, ${JSON.stringify(path)});
               if (!require.cache[p]) {
                 let module = {exports:{}};
                 process.dlopen(module, p);


### PR DESCRIPTION
Resolve native module against compiled module location instead of process cwd when using dlopen=true option.
This caused a bug when compiled module process was spawned.