### PR TITLE
Generate sourcemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ npm install --save-dev rollup-plugin-natives
 
 ## Usage
 
-In some cases you have native dependencies, maybe require by `bindings` or `node-pre-gyp`,  
-and you have to put them somewhere accessile to the rolled-up bundle.  
+In some cases you have native dependencies, maybe require by `bindings` or `node-pre-gyp`,
+and you have to put them somewhere accessile to the rolled-up bundle.
 This package is just for doing exactly this.
 
 ```js
@@ -46,6 +46,9 @@ export default {
 
             // Or a function that returns a desired file name and a specific destination to copy to
             map: (modulePath) => { name: 'filename.node', copyTo: 'C:\\Dist\\libs\\filename.node' },
+
+            // Generate sourcemap
+            sourcemap: true
         })
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,19 @@
         "universalify": "^1.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "universalify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "rollup": ">=0.56.0"
   },
   "dependencies": {
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "magic-string": "^0.25.7"
   },
   "devDependencies": {},
   "repository": "danielgindi/rollup-plugin-natives",


### PR DESCRIPTION
Thanks for this plugin! This PR adds support for generating sourcemaps (can be disabled by setting the `sourcemap` / `sourceMap` option to false).

Without this, the sourcemap generated by Rollup is broken when using the plugin.