### PR TITLE
Allow creation of recursive directories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ function nativePlugin(options) {
 
     const PREFIX = '\0natives:';
 
-    Fs.mkdirpSync(copyTo);
+    Fs.mkdirpSync(copyTo, {recursive: true});
 
     let renamedMap = /**@type {Map<String, {name: String, copyTo: String}>}*/new Map();
 


### PR DESCRIPTION
I noticed this was erroring when I wanted the plugin to generate sub-directories in the dist folder of my bundle config.

```
src/origin-response.js → dist/origin-response/index.js...
[!] (plugin rollup-plugin-natives) Error: ENOENT: no such file or directory, copyfile '/Users/christopherstumph/Repos/image-resizer/node_modules/sharp/build/Release/sharp.node' -> 'dist/origin-response/libs/sharp.node'
Error: ENOENT: no such file or directory, copyfile '/Users/christopherstumph/Repos/image-resizer/node_modules/sharp/build/Release/sharp.node' -> 'dist/origin-response/libs/sharp.node'
    at Object.copyFileSync (fs.js:1800:3)
    at Object.resolveId (/Users/christopherstumph/Repos/image-resizer/node_modules/rollup-plugin-natives/src/index.js:186:24)
    at /Users/christopherstumph/Repos/image-resizer/node_modules/rollup/dist/shared/rollup.js:18270:25
```

Config for reference:

```
{
  input: 'src/origin-response.js',
  output: {
    file: 'dist/origin-response/index.js',
    format: 'cjs',
    exports: 'named'
  },
  plugins: [
    nativePlugin({
      copyTo: 'dist/origin-response/libs',
      destDir: './libs',
      dlopen: false,
    }),
    commonjs({exclude: '*.node'}),
    nodeResolve(),
    json(),
    analyze({ onAnalysis, skipFormatted: false }),
  ],
}
```