### PR TITLE
Support node-pre-gyp options for cross-compiled modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,9 +239,14 @@ function nativePlugin(options) {
 
                     try {
                         // noinspection NpmUsedModulesInstalled
-                        preGyp = require('node-pre-gyp');
+                        preGyp = require('@mapbox/node-pre-gyp');
                     } catch (ex) {
+                      try {
+                        // noinspection NpmUsedModulesInstalled
+                        preGyp = require('node-pre-gyp');
+                      } catch (ex) {
                         return null;
+                      }
                     }
 
                     let start = match.index;

--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,7 @@ function nativePlugin(options) {
 
                 let chosenPath = possiblePaths.find(x => Fs.pathExistsSync(x)) || possiblePaths[0];
 
-                let prefixedId = mapAndReturnPrefixedId(chosenPath);
+                let prefixedId = mapAndReturnPrefixedId.apply(this, [chosenPath]);
                 if (prefixedId) {
                     return "require(" + JSON.stringify(prefixedId) + ")";
                 }
@@ -222,7 +222,7 @@ function nativePlugin(options) {
                 path = Path.join(getModuleRoot(), path);
 
                 if (Fs.pathExistsSync(path)) {
-                    let prefixedId = mapAndReturnPrefixedId(path);
+                    let prefixedId = mapAndReturnPrefixedId.apply(this, [path]);
                     if (prefixedId) {
                         return "require(" + JSON.stringify(prefixedId) + ")";
                     }
@@ -251,7 +251,7 @@ function nativePlugin(options) {
 
                     let libPath = preGyp.find(Path.resolve(Path.join(Path.dirname(id), new Function('return ' + ref)())), options);
 
-                    let prefixedId = mapAndReturnPrefixedId(libPath);
+                    let prefixedId = mapAndReturnPrefixedId.apply(this, [libPath]);
                     if (prefixedId) {
                         return `${d1} ${v1}=${JSON.stringify(renamedMap.get(libPath).name.replace(/\\/g, '/'))};${d2} ${v2}=require(${JSON.stringify(prefixedId)})`;
                     }
@@ -285,7 +285,7 @@ function nativePlugin(options) {
 
             let resolvedFull = Path.resolve(importer ? Path.dirname(importer) : '', importee);
 
-            return mapAndReturnPrefixedId(importee, importer);
+            return mapAndReturnPrefixedId.apply(this, [importee, importer]);
         },
     };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -180,8 +180,8 @@ function nativePlugin(options) {
 
                 let partsMap = {
                     'compiled': process.env.NODE_BINDINGS_COMPILED_DIR || 'compiled',
-                    'platform': process.platform,
-                    'arch': process.arch,
+                    'platform': options.target_platform || process.platform,
+                    'arch': options.target_arch || process.arch,
                     'version': process.versions.node,
                     'bindings': nativeAlias,
                     'module_root': getModuleRoot(),
@@ -249,7 +249,7 @@ function nativePlugin(options) {
 
                     let [, d1, v1, ref, d2, v2] = match;
 
-                    let libPath = preGyp.find(Path.resolve(Path.join(Path.dirname(id), new Function('return ' + ref)())));
+                    let libPath = preGyp.find(Path.resolve(Path.join(Path.dirname(id), new Function('return ' + ref)())), options);
 
                     let prefixedId = mapAndReturnPrefixedId(libPath);
                     if (prefixedId) {


### PR DESCRIPTION
This PR passes-through the plugin options to to node-pre-gyp and uses the `target_arch` and `target_platform` options, if set. Without this, it's not possible to use rollup to build a cross-compiled module, because the native module for the wrong target architecture would be included. node-pre-gyp's naming conventions clash with Rollup's, but I figured it's better to just pass-through the options as is, instead of picking out all the relevant options explicitly. The most notable options, which may need to be passed to node-pre-gyp are: `target`, `target_arch`, `target_platform`, `target_libc`, and `runtime`. With this PR we can just specify those in the plugin's options in order to bundle a cross-compiled module. 

There's a second commit here that's just a bugfix: `mapAndReturnPrefixId` was using `this.warn` to report missing native modules and therefore requires access to the plugin context. Since it's used by two hooks, I used `.apply` to expose the context.