### PR TITLE
improve node-pre-gyp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ export default {
 };
 ```
 
+### Using with node-pre-gyp
+
+`node-pre-gyp` way of determining the require path is supported only if the module code matches (almost) exactly the recommended method, ie if it looks like this:
+```js
+const binary = require('@mapbox/node-pre-gyp');
+const binding_path = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+const module = require(binding_path);
+```
+
 ## License
 
 MIT

--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ function nativePlugin(options) {
                     // Maybe node-pre-gyp is installed in node_modules/target_module/node_modules
                     let preGypPath = Path.dirname(id);
                     while (preGypPath !== '/' && preGyp === null) {
-                        // Start we the target module context and then go back in the directory tree
+                        // Start with the target module context and then go back in the directory tree
                         // until the right context has been found
                         try {
                             // noinspection NpmUsedModulesInstalled

--- a/src/index.js
+++ b/src/index.js
@@ -250,8 +250,12 @@ function nativePlugin(options) {
                     let r1 = varMatch && varMatch[4][0] === '@' ? '@mapbox/node-pre-gyp' : 'node-pre-gyp';
                     let r2 = varMatch && varMatch[4][0] === '@' ? 'node-pre-gyp' : '@mapbox/node-pre-gyp';
 
+                    // We can't simply require('node-pre-gyp') because we are not in the same context as the target module
+                    // Maybe node-pre-gyp is installed in node_modules/target_module/node_modules
                     let preGypPath = Path.dirname(id);
                     while (preGypPath !== '/' && preGyp === null) {
+                        // Start we the target module context and then go back in the directory tree
+                        // until the right context has been found
                         try {
                             // noinspection NpmUsedModulesInstalled
                             preGyp = require(Path.resolve(Path.join(preGypPath, 'node_modules', r1)));
@@ -280,6 +284,10 @@ function nativePlugin(options) {
                     return null;
                 });
 
+                // If the native module is been required through a hard-coded path, then node-pre-gyp
+                // is not required anymore - remove the require('node-pre-gyp') statement because it
+                // pulls some additional dependencies - like AWS S3 - which are needed only for downloading
+                // new binaries
                 if (hasBinaryReplacements)
                     replace(code, magicString, varRgx, () => '');
             }

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ function nativePlugin(options) {
         let result = false;
         let match;
 
-		pattern.lastIndex = 0;
+        pattern.lastIndex = 0;
         while ((match = pattern.exec(code))) {
             let replacement = fn(match);
             if (replacement === null) continue;
@@ -247,25 +247,26 @@ function nativePlugin(options) {
                 hasBinaryReplacements = replace(code, magicString, binaryRgx, (match) => {
                     let preGyp = null;
 
-					let r1 = varMatch && varMatch[4][0] === '@' ? '@mapbox/node-pre-gyp' : 'node-pre-gyp';
-					let r2 = varMatch && varMatch[4][0] === '@' ? 'node-pre-gyp' : '@mapbox/node-pre-gyp';
+                    let r1 = varMatch && varMatch[4][0] === '@' ? '@mapbox/node-pre-gyp' : 'node-pre-gyp';
+                    let r2 = varMatch && varMatch[4][0] === '@' ? 'node-pre-gyp' : '@mapbox/node-pre-gyp';
 
-					let preGypPath = Path.dirname(id);
-					while (preGypPath !== '/' && preGyp === null) {
-						try {
-							// noinspection NpmUsedModulesInstalled
-							preGyp = require(Path.resolve(Path.join(preGypPath, 'node_modules', r1)));
-						} catch (ex) {
-							try {
-								// noinspection NpmUsedModulesInstalled
-								preGyp = require(Path.resolve(Path.join(preGypPath, 'node_modules', r2)));
-							} catch (ex) {
-							}
-						}
-						preGypPath = Path.dirname(preGypPath);
-					}
+                    let preGypPath = Path.dirname(id);
+                    while (preGypPath !== '/' && preGyp === null) {
+                        try {
+                            // noinspection NpmUsedModulesInstalled
+                            preGyp = require(Path.resolve(Path.join(preGypPath, 'node_modules', r1)));
+                        } catch (ex) {
+                            try {
+                                // noinspection NpmUsedModulesInstalled
+                                preGyp = require(Path.resolve(Path.join(preGypPath, 'node_modules', r2)));
+                            } catch (ex) {
+                                // ignore
+                            }
+                        }
+                        preGypPath = Path.dirname(preGypPath);
+                    }
 
-					if (!preGyp) return null;
+                    if (!preGyp) return null;
 
                     let [, d1, v1, ref, d2, v2] = match;
 
@@ -279,8 +280,8 @@ function nativePlugin(options) {
                     return null;
                 });
 
-				if (hasBinaryReplacements)
-					replace(code, magicString, varRgx, () => '')
+                if (hasBinaryReplacements)
+                    replace(code, magicString, varRgx, () => '');
             }
 
             if (!hasBindingReplacements && !hasBinaryReplacements)


### PR DESCRIPTION
* allows searching for node-pre-gyp when it is not installed in the main package node_modules -  often it will be in node_modules/native_module/node_modules
* removes the node-pre-gyp require which pulls AWS S3 dependencies
* actually documents this very useful feature that I found about only when I decided to implement it myself :-)