### PR TITLE
Add default value to options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
 /** */
 
 
-function nativePlugin(/**RollupPluginNativesOptions*/options) {
+function nativePlugin(/**RollupPluginNativesOptions*/options = {}) {
     const copyTo = options.copyTo || './';
     const destDir = options.destDir || './';
     const dlopen = options.dlopen || false;


### PR DESCRIPTION
This allows for nativePlugin to be used as `nativePlugin()` so default settings will be used. This is the same behavior as in other Rollup plugins.