### PR TITLE
fix build not native script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,9 +108,12 @@ function nativePlugin(/**RollupPluginNativesOptions*/options) {
         let resolvedFull = Path.resolve(importer ? Path.dirname(importer) : '', importee);
 
         let nativePath = null;
-        if (/\.(node|dll)$/i.test(importee))
+        if (/\.(node|dll)$/i.test(importee)) {
+            if (Fs.pathExistsSync(resolvedFull + 'js') && !Fs.pathExistsSync(resolvedFull)) {
+                return null;
+            }
             nativePath = resolvedFull;
-        else if (Fs.pathExistsSync(resolvedFull + '.node'))
+        } else if (Fs.pathExistsSync(resolvedFull + '.node'))
             nativePath = resolvedFull + '.node';
         else if (Fs.pathExistsSync(resolvedFull + '.dll'))
             nativePath = resolvedFull + '.dll';

--- a/src/index.js
+++ b/src/index.js
@@ -108,8 +108,8 @@ function nativePlugin(/**RollupPluginNativesOptions*/options) {
         let resolvedFull = Path.resolve(importer ? Path.dirname(importer) : '', importee);
 
         let nativePath = null;
-        if (/\.(node|dll)$/i.test(importee)) {
-            if (Fs.pathExistsSync(resolvedFull + 'js') && !Fs.pathExistsSync(resolvedFull)) {
+        if (/\.(node|dll)$/i.test(importee)) {  
+            if (Fs.pathExistsSync(resolvedFull + '.js') && !Fs.pathExistsSync(resolvedFull)) {
                 return null;
             }
             nativePath = resolvedFull;


### PR DESCRIPTION
Hello,

Fix an edge-case where a file ending with `filename.node.js` imported without specifing in the `.js` extension (filename.node) was considered as a native module.

For example we had the problem with this lib: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-blob/src/utils/utils.node.ts

Have a nice day

